### PR TITLE
Fix: User creation works if group with same name already exists (#4)

### DIFF
--- a/vpn_user_data.sh
+++ b/vpn_user_data.sh
@@ -93,7 +93,7 @@ function setup_openvpnas {
 
     getent passwd ${admin_user}>/dev/null
     if [[ $? != 0 ]]; then
-      useradd ${admin_user}
+      useradd ${admin_user} -g ${admin_user}
       if [[ $? != 0 ]]; then
           echo "Failed while creating ${admin_user} user."
           exit 1


### PR DESCRIPTION
Admin user from now on also joins a group with the same name, by adding the `-g` flag in `setup_openvpnas` function.

Commit fixes https://github.com/zutherb/terraform-dcos/issues/4.

Before the following error appears in log (and the script fails to
complete):

```
Creating/updating OpenVPN administrative user admin
useradd: group admin
If you want to add this user to that group, use -g.
Failed while creating admin user.
```